### PR TITLE
Fix post_rss_feeds_handler

### DIFF
--- a/api/post_rss_feeds/main.go
+++ b/api/post_rss_feeds/main.go
@@ -11,9 +11,9 @@ import (
 func main() {
 	app, err := di.NewApp()
 	if err != nil {
-		log.Fatalf("function failed with errors: %v", err)
+		log.Fatalf("function failed with errors: %#v", err)
 		os.Exit(1)
 	}
 
-	lambda.Start(app.PostRSSFeedsHandler)
+	lambda.Start(app.PostRSSFeedsHandler.Invoke)
 }

--- a/app/handler/post_rss_feeds_handler.go
+++ b/app/handler/post_rss_feeds_handler.go
@@ -11,7 +11,7 @@ import (
 )
 
 type PostRSSFeedsHandler interface {
-	handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error)
+	Invoke(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error)
 }
 
 type postRSSFeedsHandlerImpl struct {
@@ -24,14 +24,14 @@ func NewPostRSSFeedsHandler(rssFeedRepository domain.RSSFeedRepository) PostRSSF
 	}
 }
 
-func (p postRSSFeedsHandlerImpl) handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+func (p postRSSFeedsHandlerImpl) Invoke(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	b := struct {
 		Url string `json:"url"`
 	}{}
 
 	if err := json.Unmarshal([]byte(request.Body), &b); err != nil {
 		return events.APIGatewayProxyResponse{
-			StatusCode: 500,
+			StatusCode: 400,
 		}, errors.Wrap(err, "failed json.Unmarshal()")
 	}
 

--- a/env-local.json
+++ b/env-local.json
@@ -2,7 +2,7 @@
   "Ping": {
     "DSN": "root:root@tcp(db:3306)/portfolio"
   },
-  "PostRSSFeedsFunction": {
+  "PostRSSFeeds": {
     "DSN": "root:root@tcp(db:3306)/portfolio"
   }
 }


### PR DESCRIPTION
## Why
Fixed. https://ap-northeast-1.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fportfolio-api-lambda-PostRSSFeeds-zIOebDC5d8Ge/log-events/2022$252F05$252F12$252F$255B$2524LATEST$255D448fb27edd644cd1b4b253183aa7c7bc
```sh
handler kind struct is not func: errorString
null
```